### PR TITLE
fix closing <strong> tag

### DIFF
--- a/form/tc.phtml
+++ b/form/tc.phtml
@@ -1,5 +1,5 @@
 <?php 
-	if((bool)$this->isTestMode()) echo "<p style=\"font-size:1.0em;text-align:center;background-color:#f0feff;color:#00637e;border:1px solid rgba(0, 105, 57, 0.3);padding:20px;border-radius:3px \"><strong> ".__('Choose one of the payment methods above.', 'dotpay-payment-gateway')."<br></p>";
+	if((bool)$this->isTestMode()) echo "<p style=\"font-size:1.0em;text-align:center;background-color:#f0feff;color:#00637e;border:1px solid rgba(0, 105, 57, 0.3);padding:20px;border-radius:3px \"><strong> ".__('Choose one of the payment methods above.', 'dotpay-payment-gateway')."</strong><br></p>";
 ?>
 
 <script type="text/javascript">


### PR DESCRIPTION
There was bug with closing tag, in chrome strong tag wrap li element and then lost it's woocommerce style.